### PR TITLE
cargo: add recommended Tauri release profile optimizations

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,16 @@ tauri-plugin-positioner = { version = "2.0.0", features = ["tray-icon"] }
 cocoa = "0.25"
 objc = "0.2"
 
+[profile.dev]
+incremental = true
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+panic = "abort"
+strip = true
+
 [dev-dependencies]
 tempfile = "3.8"
 


### PR DESCRIPTION
Adds [profile.release] with LTO, single codegen unit, size-optimized opt-level, panic=abort, and symbol stripping per Tauri docs.

Also enables incremental compilation for dev builds.

Closes #6